### PR TITLE
Refine UI styling and add video thumbnail fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,14 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
-     <script type="module">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+      rel="stylesheet"
+    />
+    <title>Cuidar Plus</title>
+    <script type="module">
     import { ColorSchemeScript } from '@mantine/core';
     document.head.insertAdjacentHTML('beforeend', ColorSchemeScript({ defaultColorScheme: 'light' }));
   </script>

--- a/public/placeholder.svg
+++ b/public/placeholder.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 480 270" xmlns="http://www.w3.org/2000/svg">
+  <rect width="480" height="270" fill="#e9ecef"/>
+  <polygon points="190,85 320,135 190,185" fill="#adb5bd"/>
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,9 @@
 // src/App.tsx (corrigido)
-import { MantineProvider, ColorSchemeScript, localStorageColorSchemeManager } from '@mantine/core';
+import {
+  MantineProvider,
+  ColorSchemeScript,
+  localStorageColorSchemeManager,
+} from '@mantine/core';
 import { Notifications } from '@mantine/notifications';
 import { RouterProvider } from './app/providers/RouterProvider';
 import { AuthProvider } from './features/auth/AuthContext';
@@ -11,10 +15,14 @@ export default function App() {
     <>
       <ColorSchemeScript defaultColorScheme="light" />
       <MantineProvider
-        withGlobalStyles
-        withNormalizeCSS
         defaultColorScheme="light"
         colorSchemeManager={colorSchemeManager}
+        theme={{
+          primaryColor: 'teal',
+          defaultRadius: 'md',
+          fontFamily: 'Poppins, sans-serif',
+          headings: { fontFamily: 'Poppins, sans-serif' },
+        }}
       >
         <Notifications position="top-right" />
         <AuthProvider>

--- a/src/app/layout/Navbar.tsx
+++ b/src/app/layout/Navbar.tsx
@@ -15,9 +15,9 @@ export function Navbar() {
   };
 
   return (
-    <Group px="md" py="sm" position="apart" bg="var(--mantine-color-body)">
+    <Group px="md" py="sm" justify="space-between" bg="var(--mantine-color-body)">
       <Text fw={700} size="lg">Cuidar+</Text>
-      <Group spacing="md">
+      <Group gap="md">
         <Link to="/">Início</Link>
         <Link to="/favoritos">Favoritos</Link>
         <Link to="/sobre">Sobre</Link>

--- a/src/app/routes/protected.tsx
+++ b/src/app/routes/protected.tsx
@@ -1,7 +1,8 @@
 import { Navigate } from 'react-router-dom';
 import { useAuth } from '../../features/auth/useAuth';
+import type { ReactNode } from 'react';
 
-export function ProtectedRoute({ children }: { children: JSX.Element }) {
+export function ProtectedRoute({ children }: { children: ReactNode }) {
   const { token } = useAuth();
-  return token ? children : <Navigate to="/login" replace />;
+  return token ? <>{children}</> : <Navigate to="/login" replace />;
 }

--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,4 +1,6 @@
-import { createContext, useContext, useState, ReactNode, useEffect } from 'react';
+/* eslint-disable react-refresh/only-export-components */
+import type { ReactNode } from 'react';
+import { createContext, useState, useEffect } from 'react';
 
 type AuthContextType = {
   token: string | null;
@@ -6,7 +8,7 @@ type AuthContextType = {
   logout: () => void;
 };
 
-const AuthContext = createContext<AuthContextType | undefined>(undefined);
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(null);
@@ -32,8 +34,3 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   );
 }
 
-export function useAuthContext() {
-  const context = useContext(AuthContext);
-  if (!context) throw new Error('useAuthContext must be inside AuthProvider');
-  return context;
-}

--- a/src/features/auth/useAuth.ts
+++ b/src/features/auth/useAuth.ts
@@ -1,2 +1,2 @@
-import { useAuthContext } from './AuthContext';
+import { useAuthContext } from './useAuthContext';
 export const useAuth = () => useAuthContext();

--- a/src/features/auth/useAuthContext.ts
+++ b/src/features/auth/useAuthContext.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from './AuthContext';
+
+export function useAuthContext() {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuthContext must be inside AuthProvider');
+  }
+  return context;
+}

--- a/src/features/videos/FavoritesPage.tsx
+++ b/src/features/videos/FavoritesPage.tsx
@@ -17,7 +17,7 @@ export function FavoritesPage() {
   return (
     <Container>
       <Title order={2} my="md">Favoritos</Title>
-      <SimpleGrid cols={3} spacing="md" breakpoints={[{ maxWidth: 'sm', cols: 1 }]}>
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
         {videos.map((video) => (
           <VideoCard key={video.id} {...video} />
         ))}

--- a/src/features/videos/HomePage.tsx
+++ b/src/features/videos/HomePage.tsx
@@ -2,7 +2,15 @@ import { useEffect, useState } from 'react';
 import { loadVideos } from './api';
 import type { Video } from './types';
 import { VideoCard } from './VideoCard';
-import { SimpleGrid, TextInput, Select, Container, Title } from '@mantine/core';
+import {
+  SimpleGrid,
+  TextInput,
+  Select,
+  Container,
+  Title,
+  Paper,
+  Stack,
+} from '@mantine/core';
 
 export function HomePage() {
   const [videos, setVideos] = useState<Video[]>([]);
@@ -29,26 +37,32 @@ export function HomePage() {
   return (
     <Container>
       <Title order={2} my="md">Vídeos</Title>
-      <TextInput placeholder="Buscar..." value={search} onChange={(e) => setSearch(e.currentTarget.value)} mb="sm" />
-      <Select
-        placeholder="Filtrar por categoria"
-        data={['Queimaduras','Troca de Ataduras','Higiene da Ferida','Medicação','Sinais de Alerta']}
-        value={categoria}
-        onChange={setCategoria}
-        mb="sm"
-      />
-      <Select
-        placeholder="Filtrar por duração"
-        data={[
-          { value: 'curto', label: 'Curto (< 5min)' },
-          { value: 'medio', label: 'Médio (5–10min)' },
-          { value: 'longo', label: 'Longo (> 10min)' },
-        ]}
-        value={duracao}
-        onChange={setDuracao}
-        mb="md"
-      />
-      <SimpleGrid cols={3} spacing="md" breakpoints={[{ maxWidth: 'sm', cols: 1 }]}>
+      <Paper shadow="xs" p="md" mb="md">
+        <Stack>
+          <TextInput
+            placeholder="Buscar..."
+            value={search}
+            onChange={(e) => setSearch(e.currentTarget.value)}
+          />
+          <Select
+            placeholder="Filtrar por categoria"
+            data={['Queimaduras','Troca de Ataduras','Higiene da Ferida','Medicação','Sinais de Alerta']}
+            value={categoria}
+            onChange={setCategoria}
+          />
+          <Select
+            placeholder="Filtrar por duração"
+            data={[
+              { value: 'curto', label: 'Curto (< 5min)' },
+              { value: 'medio', label: 'Médio (5–10min)' },
+              { value: 'longo', label: 'Longo (> 10min)' },
+            ]}
+            value={duracao}
+            onChange={setDuracao}
+          />
+        </Stack>
+      </Paper>
+      <SimpleGrid cols={{ base: 1, sm: 3 }} spacing="md">
         {filtered.map((video) => (
           <VideoCard key={video.id} {...video} />
         ))}

--- a/src/features/videos/VideoCard.tsx
+++ b/src/features/videos/VideoCard.tsx
@@ -22,16 +22,17 @@ export function VideoCard({ id, youtubeId, titulo, categoria, duracaoMin }: Prop
   };
 
   return (
-    <Card shadow="sm" padding="sm" radius="md" withBorder>
+    <Card className="video-card" shadow="sm" padding="sm" radius="md" withBorder>
       <Card.Section>
         <Image
           src={`https://img.youtube.com/vi/${youtubeId}/hqdefault.jpg`}
+          fallbackSrc="/placeholder.svg"
           alt={titulo}
           height={180}
         />
       </Card.Section>
 
-      <Group position="apart" mt="sm" mb="xs">
+      <Group justify="space-between" mt="sm" mb="xs">
         <Text fw={500} lineClamp={2}>{titulo}</Text>
       </Group>
 
@@ -39,7 +40,7 @@ export function VideoCard({ id, youtubeId, titulo, categoria, duracaoMin }: Prop
       <Badge color="gray" variant="light" ml="xs">{duracaoMin} min</Badge>
       {watched && <Badge color="green" variant="light" ml="xs">Visto</Badge>}
 
-      <Group mt="sm" position="apart">
+      <Group mt="sm" justify="space-between">
         <Tooltip label={fav ? 'Remover dos favoritos' : 'Adicionar aos favoritos'}>
           <ActionIcon onClick={handleToggleFavorite} color={fav ? 'red' : 'gray'}>
             {fav ? <IconHeartFilled /> : <IconHeart />}

--- a/src/features/videos/api.ts
+++ b/src/features/videos/api.ts
@@ -8,7 +8,13 @@ const videoSchema = z.object({
   titulo: z.string(),
   descricao: z.string(),
   duracaoMin: z.number(),
-  categoria: z.string(),
+  categoria: z.enum([
+    'Queimaduras',
+    'Troca de Ataduras',
+    'Higiene da Ferida',
+    'Medicação',
+    'Sinais de Alerta',
+  ]),
   materiais: z.array(z.string()),
   passos: z.array(z.string()),
   avisos: z.array(z.string()),
@@ -20,5 +26,5 @@ export async function loadVideos(): Promise<Video[]> {
     console.error('Erro de validação dos vídeos', parsed.error);
     return [];
   }
-  return parsed.data;
+  return parsed.data as Video[];
 }

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,10 +1,18 @@
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
-    Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  font-family: var(--mantine-font-family);
   background-color: var(--mantine-color-body);
 }
 a {
   text-decoration: none;
   color: inherit;
+}
+
+.video-card {
+  transition: transform 150ms ease, box-shadow 150ms ease;
+}
+
+.video-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--mantine-shadow-md);
 }


### PR DESCRIPTION
## Summary
- Apply Poppins font and teal theme via Mantine Provider
- Group filters in a Paper on home page and add hover effect to video cards
- Show placeholder thumbnails when YouTube images fail
- Refactor auth context into separate hook for lint compatibility

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e2daa64048333a09911c7fccac3e5